### PR TITLE
Directly using an RDKit mol with the `mol_col` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ mols2grid is a Python chemical viewer for 2D structures of small molecules, base
 ## Installation ℹ️
 ---
 
-mols2grid was developped for Python 3.6+ and requires rdkit, pandas and jinja2 as dependencies.
+mols2grid was developped for Python 3.6+ and requires rdkit (>=2019.09.1), pandas and jinja2 as dependencies.
 
 To install mols2grid from a clean conda environment:
 ```shell
-conda install -c conda-forge rdkit
+conda install -c conda-forge 'rdkit>=2019.09.1'
 pip install mols2grid
 ```
 
@@ -44,19 +44,20 @@ mols2grid.display("path/to/molecules.sdf",
 #### Input parameters
 
 You can setup the grid from various inputs:
-* a pandas **DataFrame** (with a column of SMILES, controlled by the `smiles_col="SMILES"` parameter),
+* a pandas **DataFrame** (with a column of SMILES or RDKit molecules, controlled by the `smiles_col` and `mol_col` parameters),
 * a list of **RDKit molecules** (with properties accessible through the `mol.GetPropsAsDict()` method),
 * or an **SDF file**
 
-You can also rename each field of your input with the `mapping` parameter. Please note that 2 fields are automatically added regardless of your input: `SMILES` and `img`. If a "SMILES" field already exists, it will not be overwritten.
+You can also rename each field of your input with the `mapping` parameter. Please note that 3 fields are automatically added regardless of your input: `mols2grid-id`, `SMILES` and `img`. If a "SMILES" field already exists, it will not be overwritten.
 
 #### Parameters for the drawing of each molecule
 
 * `useSVG=True`: use SVG images or PNG
 * `coordGen=True`: use the coordGen library instead of the RDKit one to depict the molecules in 2D
 * `size=(160, 120)`: size of each image
+* `use_coords=True`: use the coordinates of the input molecules if available
+* `remove_Hs=True`: remove hydrogen atoms from the drawings
 * and all the arguments available in RDKit's [MolDrawOptions](https://www.rdkit.org/docs/source/rdkit.Chem.Draw.rdMolDraw2D.html#rdkit.Chem.Draw.rdMolDraw2D.MolDrawOptions), like `addStereoAnnotation=True`
-
 
 #### Parameters for the grid
   

--- a/mols2grid/dispatch.py
+++ b/mols2grid/dispatch.py
@@ -37,13 +37,20 @@ def display(arg, **kwargs):
     ----------
     arg : pandas.DataFrame, SDF file or list of molecules
         The input containing your molecules
-    smiles_col : str ("SMILES")
-        If a pandas DataFrame is used, name of the columns with SMILES
+    smiles_col : str or None ("SMILES")
+        If a pandas DataFrame is used, name of the column with SMILES
+    mol_col : str or None (None)
+        If a pandas DataFrame is used, name of the column with RDKit molecules
     useSVG : bool (True)
         Use SVG images or PNG
     coordGen : bool (True)
         Use the coordGen library instead of the RDKit one to depict the
         molecules in 2D
+    use_coords : bool
+        Use the coordinates of the molecules (only relevant when an SDF file, a
+        list of molecules or a DataFrame of RDKit molecules were used as input)
+    remove_Hs : bool
+        Remove hydrogen atoms from the drawings
     size : tuple ((160, 120))
         Size of each image
     mapping : dict (None)

--- a/mols2grid/molgrid.py
+++ b/mols2grid/molgrid.py
@@ -2,11 +2,12 @@ import warnings
 from base64 import b64encode
 from html import escape
 from pathlib import Path
+from copy import deepcopy
 import pandas as pd
 from rdkit import Chem
 from rdkit.Chem import Draw
 from jinja2 import Environment, FileSystemLoader
-from .utils import requires, tooltip_formatter
+from .utils import requires, tooltip_formatter, mol_to_record
 try:
     from IPython.display import HTML
 except ModuleNotFoundError:
@@ -24,16 +25,19 @@ class MolGrid:
     """Class that handles drawing molecules, rendering the HTML document and
     saving or displaying it in a notebook
     """
-    def __init__(self, df, smiles_col="SMILES", coordGen=True, useSVG=True,
-        mapping=None, mdl_col=None, **kwargs):
+    def __init__(self, df, smiles_col="SMILES", mol_col=None, coordGen=True,
+        useSVG=True, mapping=None, **kwargs):
         """
         Parameters
         ----------
         df : pandas.DataFrame
             Dataframe containing a SMILES column and some other information 
             about each molecule
-        smiles_col : str
-            Name of the SMILES column in the dataframe
+        smiles_col : str or None
+            Name of the SMILES column in the dataframe, if available
+        mol_col : str or None
+            Name of an RDKit molecule column. If available, coordinates and 
+            atom/bonds annotations from this will be used for depiction
         coordGen : bool
             Sets whether or not the CoordGen library should be preferred to the
             RDKit depiction library
@@ -41,44 +45,25 @@ class MolGrid:
             Use SVG instead of PNG
         mapping : dict or None
             Rename the properties/fields stored in the molecule
-        mdl_col : str or None
-            Name of a Mol block column if available, 2D-coords from this will
-            be used for depiction
         kwargs : object
             Arguments passed to the `draw_mol` method
         """
+        if not (smiles_col or mol_col):
+            raise ValueError("One of `smiles_col` or `mol_col` must be set")
         Draw.rdDepictor.SetPreferCoordGen(coordGen)
         self.useSVG = useSVG
         dataframe = df.copy()
         if mapping:
             dataframe.rename(columns=mapping, inplace=True)
-        if mdl_col is not None:
-            dataframe["img"] = dataframe[mdl_col].apply(self.mdl_to_img,
-                                                        **kwargs)
-        else:
-            dataframe["img"] = dataframe[smiles_col].apply(self.smi_to_img,
-                                                        **kwargs)
+        if smiles_col and not mol_col:
+            mol_col = "mol"
+            dataframe[mol_col] = dataframe[smiles_col].apply(Chem.MolFromSmiles)
+        elif mol_col and not smiles_col:
+            dataframe["SMILES"] = dataframe[mol_col].apply(Chem.MolToSmiles)
+        dataframe["img"] = dataframe[mol_col].apply(self.mol_to_img, **kwargs)
+        dataframe["mols2grid-id"] = list(range(len(dataframe)))
         self.dataframe = dataframe
-
-    @classmethod
-    def dict_from_mol(cls, mol, mdl_col):
-        """Helper method to create dict from a RDKit molecule, adding a
-        Mol block to mdl_col if specified
-
-        Parameters
-        ----------
-        mol : RDKit molecule
-        mdl_col : str
-            Key of Mol block entry in resulting dict
-        """
-        dct = {
-            "SMILES": Chem.MolToSmiles(mol),
-            **mol.GetPropsAsDict()
-        }
-        if mdl_col is not None:
-            dct[mdl_col] = Chem.MolToMolBlock(mol)
-        return dct
-
+        self.mol_col = mol_col
 
     @classmethod
     def from_mols(cls, mols, **kwargs):
@@ -92,12 +77,9 @@ class MolGrid:
         kwargs : object
             Other arguments passed on initialization
         """
-        df = pd.DataFrame([cls.dict_from_mol(
-                            mol,
-                            kwargs['mdl_col'] if 'mdl_col' in kwargs else None
-                           )
-                           for mol in mols if mol])
-        return cls(df, **kwargs)
+        df = pd.DataFrame([mol_to_record(mol) for mol in mols if mol])
+        mol_col = kwargs.pop("mol_col", "mol")
+        return cls(df, mol_col=mol_col, **kwargs)
 
     @classmethod
     def from_sdf(cls, sdf_file, **kwargs):
@@ -110,12 +92,10 @@ class MolGrid:
         kwargs : object
             Other arguments passed on initialization
         """
-        df = pd.DataFrame([cls.dict_from_mol(
-                            mol,
-                            kwargs['mdl_col'] if 'mdl_col' in kwargs else None
-                           )
+        df = pd.DataFrame([mol_to_record(mol)
                            for mol in Chem.SDMolSupplier(sdf_file) if mol])
-        return cls(df, **kwargs)
+        mol_col = kwargs.pop("mol_col", "mol")
+        return cls(df, mol_col=mol_col, **kwargs)
 
     @property
     def template(self):
@@ -132,7 +112,8 @@ class MolGrid:
                              "Use one of 'pages' or 'table'")
         self._template = value
 
-    def draw_mol(self, mol, size=(160, 120), **kwargs):
+    def draw_mol(self, mol, size=(160, 120), use_coords=True, remove_Hs=True,
+        **kwargs):
         """Draw a molecule
 
         Parameters
@@ -141,6 +122,10 @@ class MolGrid:
             The molecule to draw
         size : tuple
             The size of the drawing canvas
+        use_coords : bool
+            Use the 2D or 3D coordinates of the molecule
+        remove_Hs : bool
+            Remove hydrogen atoms from the drawing
         **kwargs : object
             Attributes of the rdkit.Chem.Draw.rdMolDraw2D.MolDrawOptions class
             like `fixedBondLength=35, bondLineWidth=2`
@@ -158,6 +143,11 @@ class MolGrid:
         for key, value in kwargs.items():
             setattr(opts, key, value)
         d2d.SetDrawOptions(opts)
+        if not use_coords:
+            mol = deepcopy(mol)
+            mol.RemoveAllConformers()
+        if remove_Hs:
+            mol = Chem.RemoveHs(mol)
         d2d.DrawMolecule(mol)
         d2d.FinishDrawing()
         return d2d.GetDrawingText()
@@ -175,12 +165,6 @@ class MolGrid:
         """Convert a SMILES string to an HTML img tag containing a drawing of
         the molecule"""
         mol = Chem.MolFromSmiles(smi)
-        return self.mol_to_img(mol, **kwargs)
-
-    def mdl_to_img(self, mdl, **kwargs):
-        """Convert a string with MDL Mol block to an HTML img tag containing
-        a drawing of the molecule"""
-        mol = Chem.MolFromMolBlock(mdl)
         return self.mol_to_img(mol, **kwargs)
 
     def render(self, template="pages", **kwargs):
@@ -252,7 +236,7 @@ class MolGrid:
             if you want to color the text corresponding to the "Solubility"
             column in your dataframe.
         """
-        df = self.dataframe.copy()
+        df = self.dataframe.drop(columns=self.mol_col).copy()
         if subset is None:
             subset = df.columns.tolist()
             subset = [subset.pop(subset.index("img"))] + subset
@@ -290,7 +274,6 @@ class MolGrid:
             value_names = value_names[:-1] + f", {{ attr: 'style', name: {name!r} }}]"
         
         item = f'<div class="cell" data-mols2grid-id="0">{"".join(content)}</div>'
-        df["mols2grid-id"] = [str(i) for i in range(len(df))]
         df = df[final_columns].rename(columns=column_map)
         
         template = env.get_template('pages.html')
@@ -365,7 +348,7 @@ class MolGrid:
         """
         tr = []
         data = []
-        df = self.dataframe
+        df = self.dataframe.drop(columns=self.mol_col)
 
         if subset is None:
             subset = df.columns.tolist()

--- a/mols2grid/molgrid.py
+++ b/mols2grid/molgrid.py
@@ -61,6 +61,26 @@ class MolGrid:
         self.dataframe = dataframe
 
     @classmethod
+    def dict_from_mol(cls, mol, mdl_col):
+        """Helper method to create dict from a RDKit molecule, adding a
+        Mol block to mdl_col if specified
+
+        Parameters
+        ----------
+        mol : RDKit molecule
+        mdl_col : str
+            Key of Mol block entry in resulting dict
+        """
+        dct = {
+            "SMILES": Chem.MolToSmiles(mol),
+            **mol.GetPropsAsDict()
+        }
+        if mdl_col is not None:
+            dct[mdl_col] = Chem.MolToMolBlock(mol)
+        return dct
+
+
+    @classmethod
     def from_mols(cls, mols, **kwargs):
         """Set up the dataframe used by mols2grid directly from a list of RDKit
         molecules
@@ -72,8 +92,10 @@ class MolGrid:
         kwargs : object
             Other arguments passed on initialization
         """
-        df = pd.DataFrame([{"SMILES": Chem.MolToSmiles(mol),
-                            **mol.GetPropsAsDict()}
+        df = pd.DataFrame([cls.dict_from_mol(
+                            mol,
+                            kwargs['mdl_col'] if 'mdl_col' in kwargs else None
+                           )
                            for mol in mols if mol])
         return cls(df, **kwargs)
 
@@ -88,8 +110,10 @@ class MolGrid:
         kwargs : object
             Other arguments passed on initialization
         """
-        df = pd.DataFrame([{"SMILES": Chem.MolToSmiles(mol),
-                            **mol.GetPropsAsDict()}
+        df = pd.DataFrame([cls.dict_from_mol(
+                            mol,
+                            kwargs['mdl_col'] if 'mdl_col' in kwargs else None
+                           )
                            for mol in Chem.SDMolSupplier(sdf_file) if mol])
         return cls(df, **kwargs)
 

--- a/mols2grid/molgrid.py
+++ b/mols2grid/molgrid.py
@@ -25,7 +25,7 @@ class MolGrid:
     saving or displaying it in a notebook
     """
     def __init__(self, df, smiles_col="SMILES", coordGen=True, useSVG=True,
-        mapping=None, **kwargs):
+        mapping=None, mdl_col=None, **kwargs):
         """
         Parameters
         ----------
@@ -41,6 +41,9 @@ class MolGrid:
             Use SVG instead of PNG
         mapping : dict or None
             Rename the properties/fields stored in the molecule
+        mdl_col : str or None
+            Name of a Mol block column if available, 2D-coords from this will
+            be used for depiction
         kwargs : object
             Arguments passed to the `draw_mol` method
         """
@@ -49,8 +52,12 @@ class MolGrid:
         dataframe = df.copy()
         if mapping:
             dataframe.rename(columns=mapping, inplace=True)
-        dataframe["img"] = dataframe[smiles_col].apply(self.smi_to_img,
-                                                       **kwargs)
+        if mdl_col is not None:
+            dataframe["img"] = dataframe[mdl_col].apply(self.mdl_to_img,
+                                                        **kwargs)
+        else:
+            dataframe["img"] = dataframe[smiles_col].apply(self.smi_to_img,
+                                                        **kwargs)
         self.dataframe = dataframe
 
     @classmethod
@@ -145,7 +152,13 @@ class MolGrid:
         the molecule"""
         mol = Chem.MolFromSmiles(smi)
         return self.mol_to_img(mol, **kwargs)
-    
+
+    def mdl_to_img(self, mdl, **kwargs):
+        """Convert a string with MDL Mol block to an HTML img tag containing
+        a drawing of the molecule"""
+        mol = Chem.MolFromMolBlock(mdl)
+        return self.mol_to_img(mol, **kwargs)
+
     def render(self, template="pages", **kwargs):
         """Returns the HTML document corresponding to the "pages" or "table"
         template. See `to_pages` and `to_table` for the list of arguments

--- a/mols2grid/utils.py
+++ b/mols2grid/utils.py
@@ -1,5 +1,6 @@
 from functools import wraps
 from importlib.util import find_spec
+from rdkit.Chem import MolToSmiles
 
 def requires(module):
     def inner(func):
@@ -32,3 +33,9 @@ def tooltip_formatter(s, subset, fmt, style):
         v = f'<span style="{style[k](v)}">{v}</span>' if style.get(k) else v
         items.append(fmt.format(key=k, value=v))
     return "<br>".join(items)
+
+def mol_to_record(mol):
+    """Function to create a dict of data from an RDKit molecule"""
+    return {"SMILES": MolToSmiles(mol),
+            **mol.GetPropsAsDict(),
+            "mol": mol}


### PR DESCRIPTION
Added an option "mdl_col" to use coordinates allready present in DataFrame or other input. There are probably other ways to implement this, but I needed a way to draw molecules with the coordinates prepared in advance.