### PR TITLE
Update Google Colab exception to catch ImportError

### DIFF
--- a/mols2grid/select.py
+++ b/mols2grid/select.py
@@ -14,7 +14,7 @@ def del_selection(_id):
 
 try:
     from google import colab
-except ModuleNotFoundError:
+except (ModuleNotFoundError, ImportError):
     pass
 else:
     colab.output.register_callback('m2g.reset_selection', reset_selection)


### PR DESCRIPTION
@cbouy For cases where the module google exists, but colab is not installed, an ImportError is raised instead of a ModuleNotFoundError. Updating the catch to include that error. 

Encountered this when running mols2grid on streamlit. This fix solved the issue.